### PR TITLE
Fix indentation issue and string conversion issue

### DIFF
--- a/conodictor/conodictor.py
+++ b/conodictor/conodictor.py
@@ -269,7 +269,7 @@ def main():
         msg("You provided DNA fasta file")
         msg("Translating input sequences")
         do_translation(
-            str(infa),
+            infa,
             str(file_path),
         )
         inpath = Path(f"{file_path}_allpep.fa")

--- a/conodictor/conodictor.py
+++ b/conodictor/conodictor.py
@@ -178,7 +178,7 @@ def main():
                 + "for more informations.",
                 file=sys.stderr,
             )
-        sys.exit(1)
+            sys.exit(1)
 
     # Handling output directory creation
     if os.path.isdir(args.out):


### PR DESCRIPTION
The indentation change will avoid the program exit when the user runs it without docker. 
Dropping the string conversion avoids returning the error "string object has no attribute seq".